### PR TITLE
fix multiple isolated scope bug

### DIFF
--- a/source/views/index.html
+++ b/source/views/index.html
@@ -25,68 +25,8 @@
     <div class="row">
         <div class="col-sm-2 sidebar sidebar-css">
             <accordion>
-                <accordion-group heading="category1">
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-                </accordion-group>
-                <accordion-group heading="category2">
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-                </accordion-group>
-                <accordion-group heading="category3">
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-                </accordion-group>
-                <accordion-group heading="category4">
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-                </accordion-group>
-                <accordion-group heading="category5">
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-                </accordion-group>
-                <accordion-group heading="category6">
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-                </accordion-group>
-                <accordion-group heading="category7">
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
-
-                    <p>page</p>
+                <accordion-group ng-controller="AnimationsController as animations" heading="category1">
+                    <p ng-repeat="item in animations.items" ng-bind="item"></p>
                 </accordion-group>
             </accordion>
         </div>


### PR DESCRIPTION
找到问题了：`<accrodion>` 指令自己建了一个 `$scope`，`ng-controller` 指令也建了一个 `$scope`，两个 `$scope` 挂在同一个 DOM 元素下会相互覆盖。以后注意 ui-bootstrap 的自定义指令上不要绑 `ng-controller` 指令就好了。